### PR TITLE
C2C-15: Adding Implementer Interface app

### DIFF
--- a/configuration/openmrs/apps/home/extension.json
+++ b/configuration/openmrs/apps/home/extension.json
@@ -1,0 +1,82 @@
+{
+  "registration": {
+    "id": "bahmni.registration",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_REGISTRATION_KEY",
+    "url": "../registration/index.html",
+    "icon": "fa-user",
+    "order": 1,
+    "requiredPrivilege": "app:registration"
+  },
+  "clinical": {
+    "id": "bahmni.clinical",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_CLINICAL_KEY",
+    "url": "../clinical/index.html#/default/patient/search",
+    "icon": "fa-stethoscope",
+    "order": 2,
+    "requiredPrivilege": "app:clinical"
+  },
+    "adt": {
+    "id": "bahmni.adt",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_INPATIENT_KEY",
+    "url": "../adt/",
+    "icon": "icon-bahmni-inpatient",
+    "order": 3,
+    "requiredPrivilege": "app:adt"
+  },
+"radiologyDocumentUpload": {
+  "id": "bahmni.radiology.document.upload",
+  "extensionPointId": "org.bahmni.home.dashboard",
+  "type": "link",
+  "translationKey": "MODULE_LABEL_RADIOLOGY_UPLOAD_KEY",
+  "url": "../document-upload/?encounterType=RADIOLOGY&topLevelConcept=Radiology",
+  "icon": "icon-bahmni-radiology",
+  "order": 5,
+  "requiredPrivilege": "app:radiology-upload"
+},
+"patientDocumentUpload": {
+  "id": "bahmni.patient.document.upload",
+  "extensionPointId": "org.bahmni.home.dashboard",
+  "type": "link",
+  "translationKey": "MODULE_LABEL_PATIENT_DOCUMENTS_KEY",
+  "url": "../document-upload/?encounterType=Patient Document&topLevelConcept=Patient Document&defaultOption=Patient file",
+  "icon": "icon-bahmni-documents",
+  "order": 6,
+  "requiredPrivilege": "app:patient-documents"
+},
+"programs": {
+  "id": "bahmni.programs",
+  "extensionPointId": "org.bahmni.home.dashboard",
+  "type": "link",
+  "translationKey": "MODULE_LABEL_PROGRAMS_KEY",
+  "url": "../clinical/#/programs/patient/search",
+  "icon": "icon-bahmni-program",
+  "order": 7,
+  "requiredPrivilege": "app:clinical"
+},
+  "admin": {
+    "id": "bahmni.admin",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_ADMIN_KEY",
+    "url": "../admin/#/dashboard/home",
+    "icon": "icon-bahmni-admin",
+    "order":8,
+    "requiredPrivilege": "app:admin"
+},
+  "implementerInterface": {
+    "id": "bahmni.implementer.interface",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_IMPLEMENTER_INTERFACE_KEY",
+    "url": "/implementer-interface",
+    "icon": "fa fa-pencil-square-o",
+    "order": 12,
+    "requiredPrivilege": "app:implementer-interface"
+  }
+}

--- a/configuration/openmrs/apps/home/extension.json
+++ b/configuration/openmrs/apps/home/extension.json
@@ -76,7 +76,7 @@
     "translationKey": "MODULE_LABEL_IMPLEMENTER_INTERFACE_KEY",
     "url": "/implementer-interface",
     "icon": "fa fa-pencil-square-o",
-    "order": 12,
+    "order": 9,
     "requiredPrivilege": "app:implementer-interface"
   }
 }


### PR DESCRIPTION
I copied the "extension.json" file of the home app from the parent (Haiti) repo and just added a declaration for the Implementer Interface app:

`  "implementerInterface": {
    "id": "bahmni.implementer.interface",
    "extensionPointId": "org.bahmni.home.dashboard",
    "type": "link",
    "translationKey": "MODULE_LABEL_IMPLEMENTER_INTERFACE_KEY",
    "url": "/implementer-interface",
    "icon": "fa fa-pencil-square-o",
    "order": 12,
    "requiredPrivilege": "app:implementer-interface"
  }`